### PR TITLE
fix : 보안 설정 수정

### DIFF
--- a/src/main/java/com/tst/config/SecurityConfig.java
+++ b/src/main/java/com/tst/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.tst.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -42,14 +43,16 @@ public class SecurityConfig {
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .cors(Customizer.withDefaults())            // 등록된 CorsConfigurationSource를 사용
+                .cors(Customizer.withDefaults()) // 위 CORS 설정 적용
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/**").permitAll()     // 모든 경로 허용
-                        .anyRequest().authenticated()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // CORS 프리플라이트만 허용
+                        .anyRequest().authenticated()                            // 그 외엔 인증 필요
                 );
+
         return http.build();
     }
+
 }


### PR DESCRIPTION
GET 요청 자체는 CSRF 검사를 거치지 않는다 : 안전한 메소드 이기 때문에
하지만 POST,PUT,DELETE 와 같은 상태 변경 메소드는 CSRF 토근이 없으면 403 에러가 나타난다.